### PR TITLE
Svgwithcat

### DIFF
--- a/parsem
+++ b/parsem
@@ -5,4 +5,4 @@
 # Usage
 #   ./parsem <sentence>
 cd ${LIGHTBLUE}
-echo $1 | ./lightblue parse -s svg | dot -Tsvg > tmp.svg; qlmanage -p tmp.svg
+echo $1 | stack run lightblue -- parse -s svg | dot -Tsvg > tmp.svg; qlmanage -p tmp.svg

--- a/src/Interface/SVG.hs
+++ b/src/Interface/SVG.hs
@@ -107,7 +107,7 @@ cat2text category = case category of
               T.concat [
                        "S[",
                        toText pos,
-                       "&",
+                       "][",
                        toText conj,
                        "]"
                        ]

--- a/src/Interface/SVG.hs
+++ b/src/Interface/SVG.hs
@@ -103,9 +103,11 @@ cat2text category = case category of
     BS x y      -> T.concat [cat2text x, "\\\\", cat2text' y]
     T True i _     -> T.concat ["T", T.pack $ show i]
     T False i c     -> T.concat [cat2text c, "<", (T.pack $ show i), ">"]
-    S (_:(conj:_)) -> 
+    S (pos:(conj:_)) -> 
               T.concat [
                        "S[",
+                       toText pos,
+                       "&",
                        toText conj,
                        "]"
                        ]


### PR DESCRIPTION
SVG出力で、品詞(pos)情報を活用形(conj)情報の前に表示するようにしてみた。