### PR TITLE
Compnoun module update

### DIFF
--- a/src/Parser/Language/Japanese/Juman/CallJuman.hs
+++ b/src/Parser/Language/Japanese/Juman/CallJuman.hs
@@ -12,21 +12,16 @@ A module for compound nouns in Japanese.
 -}
 module Parser.Language.Japanese.Juman.CallJuman (
   MorphAnalyzerName(..)
-  -- jumanCompoundNouns,
-  --, kwjaCompoundNouns
-  , compoundNouns
+  , findCompoundNouns
   ) where
 
 import Prelude as P
 import qualified Data.Char as C           --base
 import qualified Data.Text.Lazy as T      --text
---import qualified Data.Text.Lazy.IO as T   --text
---import qualified System.Process as S      --process
 import qualified Shelly as S              -- shelly
 import Parser.CCG
 import qualified Parser.Language.Japanese.Templates as TPL
---import Debug.Trace
-
+  
 data MorphAnalyzerName = JUMAN | JUMANPP | KWJA deriving (Eq,Show)
 instance Read MorphAnalyzerName where
   readsPrec _ r =
@@ -36,62 +31,97 @@ instance Read MorphAnalyzerName where
 
 -- | Main function: jumaCompoundNouns
 -- |   given a sentence, returns a list of compound nouns
-compoundNouns :: MorphAnalyzerName -> T.Text -> IO([Node])
-compoundNouns JUMAN = fmap jumanNouns2nodes . callJuman 
-compoundNouns JUMANPP = fmap jumanNouns2nodes . callJumanpp 
-compoundNouns KWJA = fmap jumanNouns2nodes . callKWJA
+findCompoundNouns :: MorphAnalyzerName -> T.Text -> IO [Node]
+findCompoundNouns morphaName sentence = do
+  jumanData <- callMorphologicalAnalyzer morphaName sentence
+  return $ jumanNouns2nodes $ findCompNouns [] jumanData
 
--- jumanCompoundNouns :: T.Text -> IO([Node])
--- jumanCompoundNouns sentence = do
---   fmap jumanNouns2nodes $ callJuman sentence
+type PhoneticForm = T.Text
+type POS = T.Text
+type POSDetail = T.Text
+type ConjugationForm = T.Text
+type JumanData = (PhoneticForm, POS, POSDetail, ConjugationForm) -- (表層,品詞,品詞細分,（動詞なら）活用形)
 
---   -- | Main function: kwjaCompoundNouns
--- -- |   given a sentence, returns a list of compound nouns
--- kwjaCompoundNouns :: T.Text -> IO([Node])
--- kwjaCompoundNouns sentence = do
---   fmap jumanNouns2nodes $ callKWJA sentence
+callMorphologicalAnalyzer :: MorphAnalyzerName -> T.Text -> IO [JumanData]
+callMorphologicalAnalyzer morphaName sentence = do
+  let command = case morphaName of
+        JUMAN   -> \s -> T.concat ["echo ", s, " | juman"]
+        JUMANPP -> \s -> T.concat ["echo ", s, " | jumanpp"]
+        KWJA    -> \s -> T.concat ["kwja --text ", s]
+  maOutput <- S.shelly $ S.silently $ S.escaping False $ S.cmd $ S.fromText $ T.toStrict $ command sentence
+  return $ map toJumanData $ excludeCommentLines morphaName $ T.lines $ T.fromStrict maOutput
+  where 
+    -- | EOSまでの行を取得し、@+*から始まる行を除外する
+    excludeCommentLines :: MorphAnalyzerName -> [T.Text] -> [T.Text] 
+    excludeCommentLines morphanName = 
+      filter (\x -> not (isCommentLineOf morphanName x)) . P.takeWhile (/= "EOS") 
+    -- | Check if the given text is a prefix of any of the given prefixes
+    isCommentLineOf :: MorphAnalyzerName -> T.Text -> Bool
+    isCommentLineOf morphanName x = any (`T.isPrefixOf` x) $ case morphanName of
+      JUMAN   -> ["@"]
+      JUMANPP -> ["@"]
+      KWJA    -> ["@","*","+","#"]
+    -- | (表層,品詞,品詞細分,（動詞なら）活用形)の4つ組を取得
+    toJumanData :: T.Text -> JumanData 
+    toJumanData = (\l -> ((l!!0),(l!!3),(l!!5),(l!!9))) . T.split (== ' ')
 
 data JumanCompNoun = 
   JumanCompCN [T.Text] 
   | JumanCompNP [T.Text] 
   deriving (Eq,Show)
 
-type PhoneticForm = T.Text
-type POS = T.Text
-type POSDetail = T.Text
-type ConjugationForm = T.Text
+isCNcomponent :: JumanData -> Bool
+isCNcomponent (_,j2,j3,j4) 
+  | j2 == "名詞" = True
+  | j2 == "副詞" = True
+  | j3 == "名詞接頭辞" = True
+  | "名詞性名詞" `T.isPrefixOf` j3 = True
+  | "形容詞性名詞" `T.isPrefixOf` j3 = True
+  | j2 == "特殊" && j3 == "記号" = True
+  | j2 == "動詞" && j4 == "基本連用形" = True
+  | j2 == "未定義語" = True
+  | otherwise = False
 
-type JumanPair = (PhoneticForm, POS, POSDetail, ConjugationForm) -- (表層,品詞,品詞細分,（動詞なら）活用形)
+isCNsuffix :: JumanData -> Bool
+isCNsuffix (_,j2,j3,j4) 
+  | j3 == "名詞接頭辞" = True
+  | otherwise = False
 
--- | Call Juman as an external process and returns a list of juman pos-tags
-callJuman :: T.Text -> IO [JumanCompNoun]
-callJuman = callMorphologicalAnalyzer (\s -> T.concat ["echo ", s, " | juman"]) ["@"]
+isCNpostfix :: JumanData -> Bool
+isCNpostfix (_,j2,j3,j4) 
+  | j3 == "名詞接頭辞" = True
+  | otherwise = False
 
--- | Call Juman as an external process and returns a list of juman pos-tags
-callJumanpp :: T.Text -> IO [JumanCompNoun]
-callJumanpp = callMorphologicalAnalyzer (\s -> T.concat ["echo ", s, " | jumanpp"]) ["@"]
+-- | usage: findCompNouns jumanPairs [] 
+-- |   returns the list of pair (hyoso, predname)  
+findCompNouns :: [JumanCompNoun] -> [JumanData] -> [JumanCompNoun]
+findCompNouns compNouns jumanPairs =
+  case jumanPairs of
+    [] -> compNouns
+    (j1,j2,j3,j4):js | (j2 == "名詞" && j3 == "数詞") -> processingCompNoun compNouns js [j1] j3
+                     | (j2 == "動詞" && j4 == "基本連用形") -> processingCompNoun compNouns js [j1] j3
+                     | (j2 == "未定義語") -> processingCompNoun compNouns js [j1] j3
+                     | isCNcomponent (j1,j2,j3,j4) -> accepted1Noun compNouns js j1
+                     | otherwise -> findCompNouns compNouns js
 
--- | Call KWJA as an external process and returns a list of juman pos-tags
-callKWJA :: T.Text -> IO [JumanCompNoun]
-callKWJA = callMorphologicalAnalyzer (\s -> T.concat ["kwja --text ", s]) ["@","*","+","#"]
+accepted1Noun :: [JumanCompNoun] -> [JumanData] -> T.Text -> [JumanCompNoun]
+accepted1Noun compNouns jumanPairs oneNoun = 
+  case jumanPairs of
+    [] -> compNouns
+    (j1,j2,j3,j4):js -> if isCNcomponent (j1,j2,j3,j4) || j2 == "未定義語"
+                           then processingCompNoun compNouns js [j1,oneNoun] j3
+                           else findCompNouns compNouns js
 
-callMorphologicalAnalyzer :: (T.Text -> T.Text) -> [T.Text] -> T.Text -> IO [JumanCompNoun]
-callMorphologicalAnalyzer command prefixes sentence = do
-  output <- S.shelly $ S.silently $ S.escaping False $ S.cmd $ S.fromText $ T.toStrict $ command sentence
-  return $ findCompNouns [] $ getJumanPairs $ excludeSpecialPrefixes $ T.lines $ T.fromStrict output
-  where 
-    -- EOSまでの行を取得し、@+*から始まる行を除外する
-    excludeSpecialPrefixes :: [T.Text] -> [T.Text]
-    excludeSpecialPrefixes = 
-      filter (\x -> not (isPrefixOfAny prefixes x)) . P.takeWhile (/= "EOS") 
-
--- (表層,品詞,品詞細分,（動詞なら）活用形)の4つ組を取得
-getJumanPairs :: [T.Text] -> [JumanPair]
-getJumanPairs = map ((\l -> ((l!!0),(l!!3),(l!!5),(l!!9))) . (T.split (==' '))) 
-
--- | Check if the given text is a prefix of any of the given prefixes
-isPrefixOfAny :: [T.Text] -> T.Text -> Bool
-isPrefixOfAny prefixes x = any (`T.isPrefixOf` x) prefixes
+processingCompNoun :: [JumanCompNoun] -> [JumanData] -> [T.Text] -> T.Text -> [JumanCompNoun]
+processingCompNoun compNouns jumanPairs compNoun compNounHead = 
+  let newCompNoun = if "名詞" `T.isSuffixOf` compNounHead || "名詞" `T.isPrefixOf` compNounHead || "*" ==  compNounHead
+                    then (JumanCompCN compNoun)
+                    else (JumanCompNP compNoun) in
+  case jumanPairs of 
+    [] -> newCompNoun:compNouns
+    (j1,j2,j3,j4):js -> if isCNcomponent (j1,j2,j3,j4) || j2 == "未定義語"
+                           then processingCompNoun (newCompNoun:compNouns) js (j1:compNoun) j3
+                           else findCompNouns (newCompNoun:compNouns) js
 
 -- | Transforming juman pos-tags obtained from the given sentence 
 -- | into a list of (possible) compound nouns
@@ -105,47 +135,4 @@ jumanNouns2nodes jumancompnouns =
                               :(jumanNouns2nodes js))
     ((JumanCompCN j):js) -> (TPL.lexicalitem (T.concat $ reverse j) "(CompN)" 97 (N) (TPL.commonNounSR (name j)))
                               :(jumanNouns2nodes js)
-
-isCNcomponent :: JumanPair -> Bool
-isCNcomponent (_,j2,j3,j4) =
-  if j2 == "名詞" ||
-     j2 == "副詞" ||
-     j3 == "名詞接頭辞" ||
-     "名詞性名詞" `T.isPrefixOf` j3 ||
-     "形容詞性名詞" `T.isPrefixOf` j3 ||
-     (j2 == "特殊" && j3 == "記号") ||
-     (j2 == "動詞" && j4 == "基本連用形")
-     then True
-     else False
-
--- | usage: findCompNouns jumanPairs [] 
--- |   returns the list of pair (hyoso, predname)  
-findCompNouns :: [JumanCompNoun] -> [JumanPair] -> [JumanCompNoun]
-findCompNouns compNouns jumanPairs =
-  case jumanPairs of
-    [] -> compNouns
-    (j1,j2,j3,j4):js | (j2 == "名詞" && j3 == "数詞") -> processingCompNoun compNouns js [j1] j3
-                     | (j2 == "動詞" && j4 == "基本連用形") -> processingCompNoun compNouns js [j1] j3
-                     | (j2 == "未定義語") -> processingCompNoun compNouns js [j1] j3
-                     | isCNcomponent (j1,j2,j3,j4) -> accepted1Noun compNouns js j1
-                     | otherwise -> findCompNouns compNouns js
-
-accepted1Noun :: [JumanCompNoun] -> [JumanPair] -> T.Text -> [JumanCompNoun]
-accepted1Noun compNouns jumanPairs oneNoun = 
-  case jumanPairs of
-    [] -> compNouns
-    (j1,j2,j3,j4):js -> if isCNcomponent (j1,j2,j3,j4) || j2 == "未定義語"
-                           then processingCompNoun compNouns js [j1,oneNoun] j3
-                           else findCompNouns compNouns js
-
-processingCompNoun :: [JumanCompNoun] -> [JumanPair] -> [T.Text] -> T.Text -> [JumanCompNoun]
-processingCompNoun compNouns jumanPairs compNoun compNounHead = 
-  let newCompNoun = if "名詞" `T.isSuffixOf` compNounHead || "名詞" `T.isPrefixOf` compNounHead || "*" ==  compNounHead
-                    then (JumanCompCN compNoun)
-                    else (JumanCompNP compNoun) in
-  case jumanPairs of 
-    [] -> newCompNoun:compNouns
-    (j1,j2,j3,j4):js -> if isCNcomponent (j1,j2,j3,j4) || j2 == "未定義語"
-                           then processingCompNoun (newCompNoun:compNouns) js (j1:compNoun) j3
-                           else findCompNouns (newCompNoun:compNouns) js
 

--- a/src/Parser/Language/Japanese/Lexicon.hs
+++ b/src/Parser/Language/Japanese/Lexicon.hs
@@ -71,7 +71,7 @@ setupLexicon JapaneseSetA{..} sentence = do
   let mylexiconFiltered = filter (\l -> T.isInfixOf (pf l) sentence) baseLexicon
   --  3. Setting up compound nouns (returned from an execution of JUMAN)
   -- jumanCN <- JU.jumanCompoundNouns (T.replace "―" "、" sentence)
-  jumanCN <- JU.compoundNouns morphaName sentence
+  jumanCN <- JU.findCompoundNouns morphaName sentence
   --  4. Accumulating common nons and proper names entries
   let commonnouns = map (\(hyoki, (daihyo,score')) -> lexicalitem hyoki "(CN)" score' N (commonNounSR daihyo)) $ M.toList cn
   let propernames = map (\(hyoki, (daihyo,score')) -> lexicalitem hyoki "(PN)" score' ((T True 1 modifiableS `SL` (T True 1 modifiableS `BS` NP [F[Nc]]))) (properNameSR daihyo)) $ M.toList pn


### PR DESCRIPTION
・複合動詞モジュール（Parser.Language.Japanese.Juman.CallJuman）のリファクタを行い、コードからlightblueにおける複合語の定義が読み取れるように
・「数詞が消える」バグを解消