### PR TITLE
Add Parser.LangOptions module

### DIFF
--- a/app/lightblueMain.hs
+++ b/app/lightblueMain.hs
@@ -25,7 +25,8 @@ import qualified Parser.Language.Japanese.Filter as JFilter
 import Parser.Language.Japanese.Filter.KNPFilter (knpFilter)    --lightblue
 import Parser.Language.Japanese.Filter.KWJAFilter (kwjaFilter)  --lightblue
 import qualified Parser.Language.English.Lexicon as ELEX
-import Parser.Language (LangOptions(..),defaultJpOptions,defaultEnOptions)
+import Parser.Language (LangOptions(..))
+import Parser.LangOptions (defaultJpOptions,defaultEnOptions)
 import qualified Interface as I
 import qualified Interface.Text as T
 import qualified Interface.HTML as I
@@ -249,18 +250,14 @@ lightblueMain (Options lang commands style proverName filepath beamW nParse nTyp
   start <- Time.getCurrentTime
   langOptions <- case lang of
                    JP morphaName filterName -> do
-                      lightbluepath <- E.getEnv "LIGHTBLUE"
-                      jumandicData <- T.readFile $ lightbluepath ++ "src/Parser/Language/Japanese/Juman/Juman.dic"
-                      let jumanDicData = map (T.split (=='\t')) $ T.lines jumandicData
-                      return $ defaultJpOptions {
-                        baseLexicon = JLEX.myLexicon
-                        , jumanDic = jumanDicData
-                        , morphaName = morphaName
-                        , nodeFilterBuilder = case filterName of
+                        jpo <- defaultJpOptions
+                        return $ jpo {
+                          morphaName = morphaName,
+                          nodeFilterBuilder = case filterName of
                                                 JFilter.KNP  -> knpFilter
                                                 JFilter.KWJA -> kwjaFilter
                                                 JFilter.NONE -> \_ -> return (\_ _ -> id) 
-                        }
+                          }
                    EN -> return defaultEnOptions
   contents <- case filepath of
                 "-" -> T.getContents

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ library:
   - Parser.CCG
   - Parser.PartialParsing
   - Parser.Language
+  - Parser.LangOptions
   - Parser.Language.Japanese.Lexicon
   - Parser.Language.Japanese.MyLexicon
   - Parser.Language.Japanese.Templates

--- a/src/Parser/LangOptions.hs
+++ b/src/Parser/LangOptions.hs
@@ -1,0 +1,51 @@
+{-|
+Module      : Parser.LangOptions
+Copyright   : (c) Daisuke Bekki, 2025
+Licence     : All right reserved
+Maintainer  : Daisuke Bekki <bekki@is.ocha.ac.jp>
+Stability   : beta
+
+Language settings
+-}
+module Parser.LangOptions (
+  defaultJpOptions
+  , defaultEnOptions
+  ) where
+
+import GHC.Int                          --base
+import qualified System.Environment as E --base
+import qualified Data.Char as C         --base
+import qualified Data.Text.Lazy as T    --text
+import qualified Data.Text.Lazy.IO as T --text
+import qualified Parser.CCG as CCG      --lightblue
+import Parser.Language (LangOptions(..)) --lightblue
+import qualified Parser.Language.Japanese.Juman.CallJuman as JU --lightblue
+import qualified Parser.Language.Japanese.Filter as JFilter     --lightblue
+import qualified Parser.Language.Japanese.Lexicon as JLEX
+import qualified Parser.Language.Japanese.MyLexicon as JLEX
+
+defaultJpOptions :: IO LangOptions
+defaultJpOptions = do
+  lightbluepath <- E.getEnv "LIGHTBLUE"
+  jumandicData <- T.readFile $ lightbluepath ++ "src/Parser/Language/Japanese/Juman/Juman.dic"
+  return $ JpOptions {
+    existDelimiter = False
+    , symbolsToIgnore = "！？!?…◎○●▲△▼▽■□◆◇★☆※†‡"
+    , punctuations = "、，,-――／＼"
+    , periods = "。．."
+    , longestWordLength = 23
+    , baseLexicon = JLEX.myLexicon
+    , jumanDic = map (T.split (=='\t')) $ T.lines jumandicData
+    , morphaName = JU.JUMANPP
+    , nodeFilterBuilder = \_ -> return (\_ _ -> id)
+    } 
+
+defaultEnOptions :: LangOptions
+defaultEnOptions = EnOptions {
+  --name = English
+  existDelimiter = True
+  , punctuations = ","
+  , periods = "."
+  , longestWordLength = 23
+  , nodeFilterBuilder = \_ -> return (\_ _ -> id)
+  }

--- a/src/Parser/Language.hs
+++ b/src/Parser/Language.hs
@@ -8,10 +8,7 @@ Stability   : beta
 Language settings
 -}
 module Parser.Language (
-  --Language(..)
   LangOptions(..)
-  , defaultJpOptions
-  , defaultEnOptions
   ) where
 
 import GHC.Int                          --base
@@ -48,27 +45,3 @@ data LangOptions = JpOptions {
   , longestWordLength :: Int64
   , nodeFilterBuilder :: T.Text -> IO JFilter.Filter -- ^ filter for CCG nodes
   } 
-
-defaultJpOptions :: LangOptions
-defaultJpOptions = JpOptions {
-  --name = Japanese
-  existDelimiter = False
-  , symbolsToIgnore = "！？!?…◎○●▲△▼▽■□◆◇★☆※†‡"
-  , punctuations = "、，,-――／＼"
-  , periods = "。．."
-  , longestWordLength = 23
-  , baseLexicon = []
-  , jumanDic = []
-  , morphaName = JU.JUMANPP
-  , nodeFilterBuilder = \_ -> return (\_ _ -> id)
-  } 
-
-defaultEnOptions :: LangOptions
-defaultEnOptions = EnOptions {
-  --name = English
-  existDelimiter = True
-  , punctuations = ","
-  , periods = "."
-  , longestWordLength = 23
-  , nodeFilterBuilder = \_ -> return (\_ _ -> id)
-  }

--- a/src/Parser/Language/Japanese/Filter/LightblueFilter.hs
+++ b/src/Parser/Language/Japanese/Filter/LightblueFilter.hs
@@ -27,7 +27,7 @@ import qualified Data.Text.Lazy as T --text
 import qualified Parser.CCG as CCG   --lightblue
 import qualified Parser.ChartParser as LB --lightblue
 import qualified Parser.PartialParsing as LB --lightblue
-import Parser.Language (defaultJpOptions)
+import Parser.LangOptions (defaultJpOptions)
 import qualified Parser.Language.Japanese.Templates as CCG-- lightblue (verbSR,verbCat)
 import qualified Parser.Language.Japanese.MyLexicon as CCG
 import qualified Parser.Language.Japanese.Lexicon as CCG
@@ -300,7 +300,8 @@ createFilterFrom' compVerbList abcVerbList (c:cs) =
 getVerbPosConjDaihyo :: T.Text -> T.Text -> IO (T.Text)
 getVerbPosConjDaihyo fstverb sndverb = do
   --lexResource <- CCG.lexicalResourceBuilder morphAnalyzer
-  (_,lexicon) <- CCG.setupLexicon defaultJpOptions sndverb
+  langOptions <- defaultJpOptions
+  (_,lexicon) <- CCG.setupLexicon langOptions sndverb
   -- let lexicon = CCG.lookupLexicon sndverb lexicon'
   if null lexicon then D.trace ("Empty lexicon") (return $ (""))
   else do

--- a/src/Parser/Language/Japanese/Lexicon.hs
+++ b/src/Parser/Language/Japanese/Lexicon.hs
@@ -25,7 +25,7 @@ import qualified Data.Text.Lazy.IO as T  --text
 import qualified Data.List as L          -- base
 import qualified Data.Map as M           -- base
 import Parser.CCG as CCG                                        --lightblue
-import Parser.Language (LangOptions(..),defaultJpOptions)       --lightblue
+import Parser.Language (LangOptions(..))       --lightblue
 import qualified Parser.Language.Japanese.MyLexicon as LEX      --lightblue
 import Parser.Language.Japanese.Templates                       --lightblue
 import qualified Parser.Language.Japanese.Juman.CallJuman as JU --lightblue

--- a/src/Parser/PartialParsing.hs
+++ b/src/Parser/PartialParsing.hs
@@ -23,7 +23,7 @@ import qualified Data.Map as M              --container
 import qualified Parser.ChartParser as CP   --lightblue
 import qualified Parser.CCG as CCG --(Node, unaryRules, binaryRules, trinaryRules, isCONJ, cat, SimpleText)
 --import Parser.Language (jpOptions)
-import Parser.Language (defaultJpOptions)
+import Parser.LangOptions (defaultJpOptions)
 import qualified Parser.Language.Japanese.Juman.CallJuman as Juman
 
 {- Partial Parsing -}
@@ -47,7 +47,8 @@ simpleParse' :: Maybe (Int,Int)   -- ^ Debug mode: If Just (i,j), dump parse res
             -> T.Text -- ^ an input text
             -> IO ([CCG.Node],CP.Chart)
 simpleParse' ifDebug beamW ifPurify filterNodes sentence = do
-  let ps = CP.ParseSetting defaultJpOptions beamW 1 1 1 ifPurify ifDebug True False
+  langOptions <- defaultJpOptions
+  let ps = CP.ParseSetting langOptions beamW 1 1 1 ifPurify ifDebug True False
   chart <- CP.parse ps sentence
   case extractParseResult beamW chart of
     Full nodes -> return (nodes,chart)


### PR DESCRIPTION
defaultJpOptions関数をLangOptionsモジュールに移動し、内部でJuman.dicを呼び出す仕様に変更してみました。
parseWithTypeCheck関数を外部から使用する際は、parseSettingを

import Parser.LangOptions (defaultJpOptions,defaultEnOptions)
import Parser.Language.Japanese.Filter.KNPFilter (knpFilter)
import Parser.Language.Japanese.Filter.KWJAFilter (kwjaFilter)

do
langOptions <- defaultJpOptions 
let parseSetting = CP.parseSetting langOptions {morphaName = KWJA, nodeFilterBuilder = kwjaFilter} ...

のように作ってみてください。