### PR TITLE
GoalからDdB.Judgmentに変換する関数を実装

### DIFF
--- a/src/DTS/Prover/Wani/WaniBase.hs
+++ b/src/DTS/Prover/Wani/WaniBase.hs
@@ -156,10 +156,11 @@ termFromGoal (Goal _ _ maybeProofTerm _ ) = maybeProofTerm
 typesFromGoal :: Goal -> [ProofType]
 typesFromGoal (Goal _ _ _ proofTypes) = proofTypes
 
-judgmentFromGoal :: Goal -> DdB.Judgment
-judgmentFromGoal (Goal sig var maybeTerm proofTypes) =
-  A.a2dtJudgment $ A.AJudgment sig var term (head proofTypes)
-  where term = maybe (A.Conclusion $ DdB.Con "?") id maybeTerm
+goal2NeuralWaniJudgement :: Goal -> Maybe DdB.Judgment
+goal2NeuralWaniJudgement (Goal sig var maybeTerm [proofType]) =
+  Just $ A.a2dtJudgment $ A.AJudgment sig var term proofType
+  where term = maybe (A.Conclusion $ DdB.Con "neuralWaniConPlaceholder") id maybeTerm
+goal2NeuralWaniJudgement (Goal _ _ _ _) = Nothing
 
 type Rule = Goal -> Setting -> IO ([SubGoalSet],T.Text)
 


### PR DESCRIPTION
NeuralWaniのための実装です。
lightblueのdeduce'関数内でNeuralWaniを呼び出す必要があり、deduce'関数内で使われているGoalからJudgmentを取り出すために実装しました。