### PR TITLE
add runRTE and runRTEWithPreterms APIs

### DIFF
--- a/app/lightblueMain.hs
+++ b/app/lightblueMain.hs
@@ -314,14 +314,12 @@ lightblueMain (Options lang commands style proverName filepath beamW nParse nTyp
         S.putStr " ==> "
         StrictT.putStrLn $ J.hypothesis j
         S.putStr "\n"
-        let sentences = postpend (map T.fromStrict $ J.premises j) (T.fromStrict $ J.hypothesis j)
-            parseResult = NLI.parseWithTypeCheck parseSetting prover [("dummy",DTT.Entity)] [] sentences
-        PPR.printParseResult handle style 1 noTypeCheck False title parseResult
-        inferenceLabels <- toList $ NLI.trawlParseResult parseResult
-        let groundTruth = J.jsemLabel2YesNo $ J.answer j
-            prediction = case inferenceLabels of
-              [] -> J.Other
-              (bestLabel:_) -> bestLabel
+        let premises = map T.fromStrict $ J.premises j
+            hypothesis = T.fromStrict $ J.hypothesis j
+        rteResult <- NLI.runRTE parseSetting prover [("dummy",DTT.Entity)] [] premises hypothesis
+        let prediction = NLI.rteLabel rteResult
+            groundTruth = J.jsemLabel2YesNo $ J.answer j
+        PPR.printParseResult handle style 1 noTypeCheck False title (NLI.rteParseResult rteResult)
         S.putStrLn $ "\nPrediction: " ++ (show prediction) ++ "\nGround truth: " ++ (show groundTruth) ++ "\n"
         return (prediction, groundTruth)
       T.putStrLn $ T.fromStrict $ NLP.showClassificationReport pairs


### PR DESCRIPTION
NeuralWaniの評価用のコードを使用するために、Pretermの形でRTEを行える関数（runRTEWithPreterms）を作成しました。
他の差分はリファクタリングです。

TPTP Problemをこの関数に渡して動作することを確認済みです。
https://github.com/miyagawananako/neuralWani/blob/a947027a5612c09e5bacb79da6287e81e1302da3/app/evaluate/Main.hs#L228