### PR TITLE
express: CCG用語に合わせたUIラベル変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The global options are common to all commands.
 |```--depth <int>```                      | ```2``` |Set expansion depth of syntactic structures|
 |```--noShowCat```                        |     |If specified, hide syntactic categories|
 |```--noShowSem```                        |     |If specified, hide semantics|
-|```--leafVertical```                     |     |If specified, list leaf nodes vertically|
+|```--leafVertical```                     |     |If specified, list lexical items vertically|
 |```--browser {chrome\|firefox\|default}``` | ```default``` |Choose the browser to launch the Express UI. If omitted, the system default browser is used.|
 
 ### For developpers ###

--- a/app/lightblueMain.hs
+++ b/app/lightblueMain.hs
@@ -232,7 +232,7 @@ optionParser =
       <> help "If True, hide semantics in Express view" )
     <*> switch
       ( long "leafVertical"
-      <> help "If True, list leaf nodes vertically in Express view" )
+      <> help "If True, list lexical items vertically in Express view" )
     <*> optional (option expressBrowserReader
       ( long "browser"
       <> metavar "chrome|firefox|default"

--- a/src/Interface/Express/Express.hs
+++ b/src/Interface/Express/Express.hs
@@ -214,7 +214,7 @@ getParsingR = do
                       <label for="TAB-#{tabNum}" class=#{tabClass}>#{tabNum} (score: #{score})
                       <div class="tab-content">
                         <div class="tab-leaves">
-                          <h2>Leaf Nodes
+                          <h2>Lexical Items
                           <div .leaf-node-list :WE.leafVertical dsp:.vertical>
                             $forall leaf <- leafNodes
                               <div .leaf-node-item>^{WE.widgetizeWith dsp leaf}

--- a/src/Interface/Express/templates/express.julius
+++ b/src/Interface/Express/templates/express.julius
@@ -244,7 +244,7 @@ if (document.readyState === 'loading') {
   });
 })();
 
-// 解析候補のプレビュー描画（サーバ側の Leaf Node レイアウトを取得して埋め込み）
+// 解析候補のプレビュー描画（サーバ側の Lexical Items レイアウトを取得して埋め込み）
 function renderSpanPreviews(nodes, ctx) {
   const container = document.getElementById('span-preview-list');
   if (!container) return;


### PR DESCRIPTION
## 変更点
- "Leaf Nodes" → "Lexical Items"
- "Node" → "Syntactic Structures"
- READMEの用語/typoの微修正

## 影響
- 表示のみ
- 機能変更なし