### PR TITLE
add eqEnable

### DIFF
--- a/src/DTS/Prover/Wani/Forward.hs
+++ b/src/DTS/Prover/Wani/Forward.hs
@@ -162,8 +162,8 @@ forEq context term =
                   arEqTypes)
     Nothing -> ([],[])
 
-forwardContext :: A.SAEnv -> A.AEnv -> B.Result
-forwardContext sig var = 
+forwardContext :: Bool ->A.SAEnv -> A.AEnv -> B.Result
+forwardContext eqEnabled sig var = 
     let (sigNames,sigTerms) = unzip sig
         context' = var ++ sigTerms
         varsigmaForwarded =
@@ -189,7 +189,7 @@ forwardContext sig var =
               (L.tails  context')) 
         trees =   
           let eqIntroTree = UDT.Tree QT.Var (A.AJudgment sig var (A.Conclusion $DdB.Con "forwardEqIntro") eqIntro) []
-              sigmaForwarded = eqIntroTree :
+              sigmaForwarded = (if eqEnabled then (eqIntroTree :) else id) $
                     map
                       (\aTree  ->
                         case aTree of
@@ -209,7 +209,7 @@ forwardContext sig var =
                           _ -> aTree
                       )
                       varsigmaForwarded
-          in (eqForwards2' sigmaForwarded)  ++ sigmaForwarded
+          in (if eqEnabled then ((eqForwards2' sigmaForwarded)  ++) else id) sigmaForwarded
     in B.resultDef{B.trees = trees}
 
 

--- a/src/DTS/Prover/Wani/Prove.hs
+++ b/src/DTS/Prover/Wani/Prove.hs
@@ -84,7 +84,8 @@ prove' QT.ProofSearchSetting{..} (DdB.ProofSearchQuery sig ctx typ) =  -- LiftT 
         WB.debug = -1,
         WB.sStatus = WB.statusDef,
         WB.oracle = oracle,
-        WB.oracleThreshold=0.5
+        WB.oracleThreshold=0.5,
+        WB.enableEq = True
         };
       ioResult = hojo ctx ((A.aEntityName,DdB.Type):sig) typ setting (M.maybe Nothing (\t -> M.Just $ toEnum (t * (10^9))) maxTime)
   in ListT.lift ioResult >>= \result ->

--- a/src/DTS/Prover/Wani/WaniBase.hs
+++ b/src/DTS/Prover/Wani/WaniBase.hs
@@ -90,7 +90,8 @@ data Setting = Setting
    ruleConHojo :: String,
    timeLimit :: M.Maybe Time.UTCTime,
    oracle :: Maybe (DdB.ConName -> DdB.ConName -> Float),
-   oracleThreshold :: Float
+   oracleThreshold :: Float,
+   enableEq :: Bool
    } -- deriving (Show,Eq)
 
 data Result = Result
@@ -110,7 +111,7 @@ statusDef :: Status
 statusDef = Status{failedlst=[],usedMaxDepth = 0,deduceNgLst=[],usedDisJoint=[],allProof = True}
 
 settingDef :: Setting
-settingDef = Setting{mode = Plain,falsum = True,maxdepth = 9,maxtime = 100000,debug = 0,sStatus = statusDef,ruleConHojo = "sub",oracle=M.Nothing,oracleThreshold=0.5}
+settingDef = Setting{mode = Plain,falsum = True,maxdepth = 9,maxtime = 100000,debug = 0,sStatus = statusDef,ruleConHojo = "sub",oracle=M.Nothing,oracleThreshold=0.5,enableEq=True}
 
 resultDef :: Result
 resultDef = Result{trees = [],errMsg = "",rStatus = statusDef}


### PR DESCRIPTION
> https://github.com/DaisukeBekki/lightblue/blob/enhance235/src/DTS/Prover/Wani/Prove.hs#L88
`WB.enableEq = False` にすると等号型関係の規則がオフになります