### PR TITLE
wani への Concurrent の導入

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -71,6 +71,7 @@ dependencies:
   - http-client-tls >= 0.3.5
   - dotenv >= 0.0.4
   - deepseq
+  - async >= 2.2.4
 
 library:
   source-dirs: src

--- a/src/DTS/Prover/Wani/Prove.hs
+++ b/src/DTS/Prover/Wani/Prove.hs
@@ -85,7 +85,8 @@ prove' QT.ProofSearchSetting{..} (DdB.ProofSearchQuery sig ctx typ) =  -- LiftT 
         WB.sStatus = WB.statusDef,
         WB.oracle = oracle,
         WB.oracleThreshold=0.5,
-        WB.enableEq = True
+        WB.enableEq = True,
+        WB.enableConcurrent = True
         };
       ioResult = hojo ctx ((A.aEntityName,DdB.Type):sig) typ setting (M.maybe Nothing (\t -> M.Just $ toEnum (t * (10^9))) maxTime)
   in ListT.lift ioResult >>= \result ->

--- a/src/DTS/Prover/Wani/WaniBase.hs
+++ b/src/DTS/Prover/Wani/WaniBase.hs
@@ -91,7 +91,8 @@ data Setting = Setting
    timeLimit :: M.Maybe Time.UTCTime,
    oracle :: Maybe (DdB.ConName -> DdB.ConName -> Float),
    oracleThreshold :: Float,
-   enableEq :: Bool
+   enableEq :: Bool,
+   enableConcurrent :: Bool
    } -- deriving (Show,Eq)
 
 data Result = Result
@@ -111,7 +112,7 @@ statusDef :: Status
 statusDef = Status{failedlst=[],usedMaxDepth = 0,deduceNgLst=[],usedDisJoint=[],allProof = True}
 
 settingDef :: Setting
-settingDef = Setting{mode = Plain,falsum = True,maxdepth = 9,maxtime = 100000,debug = 0,sStatus = statusDef,ruleConHojo = "sub",oracle=M.Nothing,oracleThreshold=0.5,enableEq=True}
+settingDef = Setting{mode = Plain,falsum = True,maxdepth = 9,maxtime = 100000,debug = 0,sStatus = statusDef,ruleConHojo = "sub",oracle=M.Nothing,oracleThreshold=0.5,enableEq=True,enableConcurrent=False}
 
 resultDef :: Result
 resultDef = Result{trees = [],errMsg = "",rStatus = statusDef}


### PR DESCRIPTION
https://github.com/DaisukeBekki/lightblue/blob/enhance244/src/DTS/Prover/Wani/Prove.hs#L89

デフォルトでは並列で計算するモードが有効化されています．enableConcurrent を False にすると並列化を伴わない計算をします．
デバッグ目的や neuralWani 等での高速化の効力を測りたいときは False にするといいと思います．

wanitest でそれっぽい動きをすることを確認済みですが網羅できていないと思うので，wani をご使用の皆さまに軽く挙動確認いただけるととても嬉しいです．
