### PR TITLE
gitignore: ignore client_session_key.aes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ src/.ftpconfig
 stack.yaml.lock
 config.yaml
 .env
+
+client_session_key.aes


### PR DESCRIPTION
セッション秘密鍵 client_session_key.aes の誤コミットを防ぐため .gitignore に追加