### PR TITLE
chore: .venvを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ stack.yaml.lock
 config.yaml
 .env
 .DS_Store
-
+.venv/
 client_session_key.aes


### PR DESCRIPTION
Pythonの仮想環境ディレクトリ（`.venv/`）がGitの追跡対象に含まれていたため、`.gitignore` に追加しました。