### PR TITLE
feat: add toggleable signature display to proof search queries

### DIFF
--- a/src/Interface/Express/Express.hs
+++ b/src/Interface/Express/Express.hs
@@ -1258,10 +1258,18 @@ getProofQueryR = do
     Nothing -> defaultLayout [whamlet|<pre>loading...</pre>|]
     Just psq -> do
       -- Convert deBruijn to with-name for display
-      let psqWN = DWN.fromDeBruijnProofSearchQuery psq
+      let psqWN@(DWN.ProofSearchQuery sigWN _ _) = DWN.fromDeBruijnProofSearchQuery psq
+          kindT = maybe "pos" id mk
       defaultLayout $ do
         [whamlet|
           <div class="tab-tcq-content-inference">^{WE.widgetizeWith dsp psqWN}
+          <div .ps-sig>
+            <button type="button" .btn id="ps-sig-btn-#{kindT}" onclick="toggleSignature('#{kindT}')">Show Signature
+            <div .ps-sig-body id="ps-sig-body-#{kindT}" style="display: none">
+              $if null sigWN
+                <span .ps-sig-empty>(empty)
+              $else
+                <div class="tab-tcq-content-inference">^{WE.widgetizeWith dsp sigWN}
         |]
 
 -- Start proving (pos/neg) lazily after /proofsearch renders

--- a/src/Interface/Express/WidgetExpress.hs
+++ b/src/Interface/Express/WidgetExpress.hs
@@ -689,15 +689,16 @@ instance Widgetizable QT.DTTrule where
 
 -- type Signature = [(T.Text, Preterm)]
 instance Widgetizable DTT.Signature where
-  widgetize signature = 
+  widgetize signature =
     let reversedItems = reverse signature
         itemsWithFlags = case reversedItems of
           [] -> []
-          _  -> zip reversedItems (repeat False) ++ [(last reversedItems, True)]
+          _  -> zip (init reversedItems) (repeat False) ++ [(last reversedItems, True)]
     in [whamlet|
        <mrow>
          $forall ((nm, tm), isLast) <- itemsWithFlags
-           <math xmlns="http://www.w3.org/1998/Math/MathML">^{widgetize nm}
+           <math xmlns="http://www.w3.org/1998/Math/MathML">
+             <mtext>#{nm}
            <mo>:
            <math xmlns="http://www.w3.org/1998/Math/MathML">^{widgetize tm}
            $if not isLast
@@ -706,16 +707,17 @@ instance Widgetizable DTT.Signature where
 
 -- type Signature = [(T.Text, Preterm)]
 instance Widgetizable DWN.Signature where
-  widgetize signature = 
+  widgetize signature =
     let reversedItems = reverse signature
         itemsWithFlags = case reversedItems of
           [] -> []
-          _  -> zip reversedItems (repeat False) ++ [(last reversedItems, True)]
+          _  -> zip (init reversedItems) (repeat False) ++ [(last reversedItems, True)]
     in [whamlet|
        <math xmlns="http://www.w3.org/1998/Math/MathML">
        <mrow>
          $forall ((nm, tm), isLast) <- itemsWithFlags
-           <math xmlns="http://www.w3.org/1998/Math/MathML">^{widgetize nm}
+           <math xmlns="http://www.w3.org/1998/Math/MathML">
+             <mtext>#{nm}
            <mo>:
            <math xmlns="http://www.w3.org/1998/Math/MathML">^{widgetize tm}
            $if not isLast

--- a/src/Interface/Express/templates/express.julius
+++ b/src/Interface/Express/templates/express.julius
@@ -31,6 +31,16 @@ function toggle(id){
             }
 };
 
+// Toggle signature visibility on ProofSearch query cards
+function toggleSignature(kind){
+  const body = document.getElementById('ps-sig-body-' + kind);
+  const btn = document.getElementById('ps-sig-btn-' + kind);
+  if (!body || !btn) return;
+  const show = body.style.display === 'none';
+  body.style.display = show ? 'block' : 'none';
+  btn.textContent = show ? 'Hide Signature' : 'Show Signature';
+}
+
 // Toggle label active state for cat/sem controls in header
 function initToggleButtons() {
   const cat = document.getElementById('cat-toggle');

--- a/src/Interface/Express/templates/proofsearch.cassius
+++ b/src/Interface/Express/templates/proofsearch.cassius
@@ -75,6 +75,18 @@
 .ps-body
   padding: 60px
 
+.ps-sig
+  margin-top: 16px
+  padding-top: 10px
+  border-top: 1px dashed #eee
+
+.ps-sig-body
+  margin-top: 10px
+  overflow-x: auto
+
+.ps-sig-empty
+  color: #999
+
 .ps-outcome
   display: inline-block
   padding: 4px 12px


### PR DESCRIPTION
close: https://github.com/DaisukeBekki/lightblue/issues/273

Proof Search 画面の各 Proof Search Query (pos/neg) に Signature を表示できるようにしました。

- 各クエリの下部に「Show Signature」ボタンを追加しました(デフォルトは非表示です)


https://github.com/user-attachments/assets/913573a9-e6df-4ce8-8f5a-d74525b62abc

